### PR TITLE
Leaderboard endpoints

### DIFF
--- a/db.js
+++ b/db.js
@@ -97,6 +97,19 @@ function redisView(view, persistent) {
 exports.redisView = redisView;
 
 
+function plsNoError(res, done, callback) {
+    return function(err, result) {
+        if (err) {
+            res.json(500, {error: 'db_error'});
+            done();
+            return;
+        }
+        callback(result);
+    };
+}
+exports.plsNoError = plsNoError;
+
+
 function flatDB() {}
 flatDB.prototype = {
     write: function(type, slug, data, callback) {

--- a/lib/leaderboard.js
+++ b/lib/leaderboard.js
@@ -1,5 +1,5 @@
 var isLeaderboard = exports.isLeaderboard = function(conn, game, board, callback) {
-    conn.sismember('leaderboards:' + game, board, function(err, reply) {
+    conn.hexists('leaderboards:' + game, board, function(err, reply) {
         callback(!err && reply);
     });
 };

--- a/views/game/board.js
+++ b/views/game/board.js
@@ -1,28 +1,31 @@
 var _ = require('lodash');
 
+var auth = require('../../lib/auth');
 var db = require('../../db');
+var user = require('../../lib/user');
 
 
 module.exports = function(server) {
     // Sample usage:
-    // % curl 'http://localhost:5000/game/mario-bros/boards'
+    // % curl 'http://localhost:5000/game/mario-bros/board'
     server.get({
-        url: '/game/:game/boards',
+        url: '/game/:game/board',
         swagger: {
             nickname: 'get-board',
             notes: 'Returns a list of the leaderboards boards that are ' +
                    'available for a particular game.',
-            summary: 'Create a Game Leaderboard'
+            summary: 'List of Leaderboards for a Game'
         }
     }, db.redisView(function(client, done, req, res, wrap) {
         var DATA = req.params;
 
         // TODO: Check for valid game.
-        // TODO: Accept ID *or* slug.
+        // https://github.com/cvan/galaxy-api/issues/57
         var game = DATA.game;
         if (!game) {
             res.json(400, {error: 'bad_game'});
             done();
+            return;
         }
 
         // TODO: wrap
@@ -30,19 +33,11 @@ module.exports = function(server) {
             if (err) {
                 res.json(400, {error: true});
                 done();
+                return;
             }
-            boards.forEach(function(board) {
-                board = JSON.parse(board);
-                // client.zrange('leaderboards:' + game + ':' + board.slug, 0, -1, function(err, scores) {
-                //     if (err) {
-                //         res.json(400, {error: true});
-                //         done();
-                //     }
-                //     board.scores = JSON.parse(scores);
-                //     console.log(board);
-                // });
-            });
 
+            // TODO: Consider returning the default output of the board
+            boards = boards.map(JSON.parse);
             res.json(boards);
             done();
         });
@@ -74,11 +69,12 @@ module.exports = function(server) {
         var slug = DATA.slug;
 
         // TODO: Check for valid game.
-        // TODO: Accept ID *or* slug.
+        // https://github.com/cvan/galaxy-api/issues/67        
         var game = DATA.game;
         if (!game) {
             res.json(400, {error: 'bad_game'});
             done();
+            return;
         }
 
         var data = {
@@ -90,9 +86,9 @@ module.exports = function(server) {
         client.hset('leaderboards:' + game, slug, JSON.stringify(data), function(err, reply) {
             if (err) {
                 res.json(400, {error: true});
-                done();
+            } else {
+                res.json({success: true});
             }
-            res.json({success: true});
             done();
         });
     }));
@@ -118,21 +114,158 @@ module.exports = function(server) {
         var slug = DATA.slug;
 
         // TODO: Check for valid game.
-        // TODO: Accept ID *or* slug.
+        // https://github.com/cvan/galaxy-api/issues/57
         var game = DATA.game;
         if (!game) {
             res.json(400, {error: 'bad_game'});
             done();
+            return;
         }
 
         // TODO: wrap
         client.hdel('leaderboards:' + game, slug, function(err, reply) {
             if (err) {
                 res.json(400, {error: true});
-                done();
+            } else {
+                res.json({success: true});
             }
-            res.json({success: true});
             done();
         });
     }));
-};
+
+    // Sample usage:
+    // % curl 'http://localhost:5000/game/mario-bros/board/warios-smashed'
+    // % curl 'http://localhost:5000/game/mario-bros/board/warios-smashed?sort=asc&friendsOnly=true&_user=ssa_token'
+    server.get({
+        url: '/game/:game/board/:board',
+        swagger: {
+            nickname: 'get-scores',
+            notes: 'Returns the list of scores of a particular leaderboard',
+            summary: 'List of Scores for LeaderBoard'
+        },
+        validation: {
+            sort: {
+                description: 'Sort order',
+                isAlpha: true,
+                isRequired: false
+            },
+            friendsOnly: {
+                description: 'Only show score of friends',
+                isRequired: false
+            },
+            _user: {
+                description: 'User (ID or username slug)',
+                isRequired: false
+            },
+            page: {
+                description: 'Page number',
+                isInt: true,
+                isRequired: false
+            },
+            limit: {
+                description: 'Number of results per page',
+                isInt: true,
+                isRequired: false
+            }
+        }
+    }, db.redisView(function(client, done, req, res, wrap) {
+        var DATA = req.params;
+
+        // TODO: Check for valid game. 
+        // https://github.com/cvan/galaxy-api/issues/57
+        var game = DATA.game;
+        if (!game) {
+            res.json(400, {error: 'bad_game'});
+            done();
+            return;
+        }
+
+        // TODO: Check for valid leaderboard
+        // https://github.com/cvan/galaxy-api/issues/57
+        var board = DATA.board;
+        if (!board) {
+            res.json(400, {error: 'bad_board'});
+            done();
+            return;            
+        }
+
+        var sortDesc = DATA.sort !== 'asc';
+
+        var friendsOnly = DATA.friendsOnly;
+        var _user = DATA._user;
+        var email;
+
+        // TODO: Verify the default limits
+        // https://github.com/cvan/galaxy-api/issues/67
+        var page = DATA.page ? parseInt(DATA.page, 10) : 0;
+        var limit = DATA.limit ? parseInt(DATA.limit, 10) : 10;
+
+        var start = page * limit;
+        var stop = start + limit - 1;
+
+        if (friendsOnly) {
+            if (!_user) {
+                res.json(403, {error: 'missing_user'});
+                done();
+                return;
+            } else if (!(email = auth.verifySSA(_user))) {
+                res.json(403, {error: 'bad_user'});
+                done();
+                return;
+            }
+        }
+
+        function outputResult(result) {
+            if(!result || result.length == 0) {
+                res.json([]);
+                done();
+                return;
+            }
+
+            var realResult = {};
+            var userIds = [];
+            for (var i = 0; i < result.length; i += 2) {
+                userIds.push(result[i]);
+                realResult[result[i]] = result[i + 1];
+            }
+
+            user.getPublicUserObjList(client, userIds, function(objs) {
+                res.json(objs.map(function(obj) {
+                    return {user: obj, score: realResult[obj.id]};
+                }));
+                done();
+            });
+        }
+
+        var key = 'leaderboards:' + game + ':' + board;
+        var zRangeFunc = sortDesc ? 'zrevrange' : 'zrange';
+
+        if (friendsOnly) {
+            user.getUserIDFromEmail(client, email, db.plsNoError(res, done, function(id) {
+                var randomValue = Math.floor(Math.random() * 10000);
+                var interstoreKey = key + ':' + id + ':' + randomValue;
+                var friendsKey = 'friends:' + id;
+
+                var multi = client.multi();
+                // Create a temporary zset, containing only the scores of the user's friends
+                multi.zinterstore(interstoreKey, 2, key, friendsKey, 'AGGREGATE', 'MAX');
+
+                // Retrieve the scores from the temp zset
+                multi[zRangeFunc](interstoreKey, start, stop, 'WITHSCORES');
+
+                // Remove the temp zset
+                multi.del(interstoreKey);
+
+                // Execute the above mult command in an atomic fashion
+                multi.exec(db.plsNoError(res, done, function(reply) {
+                    outputResult(reply[1]);
+                }));
+            }));
+        } else {
+            var arguments = [key, start, stop, 'WITHSCORES'];
+            client[zRangeFunc](arguments, db.plsNoError(res, done, function(scores) {
+                outputResult(scores);
+            }));
+        }
+    }));
+}


### PR DESCRIPTION
Most of the work that I've done here is to retrieve the scores for individual leaderboards of a game, which is the `GET /api/v1/game/<game>/board/<board>` endpoint. For now, the `GET /api/v1/game/<game>/board` does not include the default output of the specific endpoint. (Only shows the name and the slug) https://github.com/cvan/galaxy-api/issues/62

For the `GET /api/v1/game/<game>/board/<board>` endpoint:

**Optional Parameters**
`sort`: `asc` or `desc` (default: `desc`)
`friendsOnly`: `true` or `false` (default: `false`)
 `_user`: user's ssa token. Required when `friendsOnly` is true. The code will checks the token when this parameter is specified, no matter `friendsOnly` is true or false
`page`: Page number. Defaults to 0
`limit`: Number of scores per page. Defaults to 10

See https://github.com/soedar/galaxy-api/blob/master/views/game/board.js#L194 for page start/stop calculation

**Sample Output**

``` javascript
[
    {
        "user": {
            "avatar": "http://www.gravatar.com/avatar/52ee5da3a600790b01386b551ec2e36a",
            "username": "1234",
            "id": "1234"
        },
        "score": "200"
    },
    {
        "user": {
            "avatar": "http://www.gravatar.com/avatar/8c5a1bf958ec4bbdfafc8a2fb4614b75",
            "username": "soedar.sg",
            "id": "b27911cf-7fe7-4c95-80e8-0db204e571cf"
        },
        "score": "10"
    }
]
```
