### PR TITLE
Send back game objects from featured endpoint

### DIFF
--- a/views/game/featured.js
+++ b/views/game/featured.js
@@ -33,9 +33,9 @@ module.exports = function(server) {
             client.hkeys('featured', db.plsNoError(res, done, function(games) {
                 // Get Game Objects
                 gamelib.getGameList(client, null, function(objList) {
-                    //Filter by featured
+                    // Filter by featured
                     res.json(_.filter(objList, function(gameObj) {
-                      return games.indexOf(gameObj.slug) !== -1;  
+                        return games.indexOf(gameObj.slug) !== -1;  
                     }));
                     return done();
                 });


### PR DESCRIPTION
Change JSON response of /featured endpoint to return objects instead of
slugs. Needed for [galaxy/124](https://github.com/cvan/galaxy/issues/124)

r? @soedar @cvan
