### PR TITLE
Updated filterable statuses for game/list endpoint

### DIFF
--- a/views/game/list.js
+++ b/views/game/list.js
@@ -32,7 +32,7 @@ module.exports = function(server) {
             status: {
                 description: 'Filter by current status of the game',
                 isRequired: false,
-                isIn: ['approved', 'pending', 'rejected']
+                isIn: ['approved', 'pending', 'rejected', 'disabled', 'deleted']
             }
         }
     }, db.redisView(function(client, done, req, res, wrap) {


### PR DESCRIPTION
Updated list of valid statuses to filter by to include 'deleted' and
'disabled' (required for [galaxy/#121](https://github.com/cvan/galaxy/issues/121))
