### PR TITLE
Fixed parsing of requests with a URL-encoded body

### DIFF
--- a/server_http.js
+++ b/server_http.js
@@ -12,7 +12,7 @@ var server = restify.createServer({
 });
 
 server.use(restify.acceptParser(server.acceptable));
-server.use(restify.bodyParser({mapParams: false}));
+server.use(restify.bodyParser());
 server.use(restify.CORS());
 server.use(restify.gzipResponse());
 server.use(restify.queryParser());

--- a/views/feedback.js
+++ b/views/feedback.js
@@ -33,11 +33,7 @@ module.exports = function(server) {
             summary: 'Submit feedback for a site page'
         }
     }, db.redisView(function(client, done, req, res, wrap) {
-        var fbData = req.body;
-        if (typeof fbData !== 'object') {
-            res.json(400, {error: 'bad_json_request'});
-            return done();
-        }
+        var fbData = req.params;
 
         // TODO: use potato-captcha to verify real feedback
         var requiredKeys = ['page_url', 'feedback'];

--- a/views/game/submit.js
+++ b/views/game/submit.js
@@ -39,14 +39,8 @@ module.exports = function(server) {
             return done();
         }
 
-        var gameData = req.body;
-        if (typeof gameData != 'object') {
-            res.json(400, {error: 'bad_json_request'});
-            return done();
-        }
-
         var requiredKeys = ['app_url', 'homepage_url', 'icons', 'name', 'screenshots'];
-        gameData = validateGameData(gameData, requiredKeys);
+        var gameData = validateGameData(req.params, requiredKeys);
         if (!gameData) {
             res.json(400, {error: 'bad_game_data'});
             return done();
@@ -76,14 +70,8 @@ module.exports = function(server) {
         var PUT = req.params;
         var slug = PUT.slug;
 
-        var gameData = req.body;
-        if (typeof gameData != 'object') {
-            res.json(400, {error: 'bad_json_request'});
-            return done();
-        }
-
         var requiredKeys = ['app_url', 'homepage_url', 'icons', 'name', 'screenshots', 'slug'];
-        gameData = validateGameData(gameData, requiredKeys);
+        var gameData = validateGameData(PUT, requiredKeys);
         if (!gameData) {
             res.json(400, {error: 'bad_game_data'});
             return done();


### PR DESCRIPTION
~~Disabled the `mapParams` option of restify's bodyParser plugin so that the
parsed data from a URL-encoded POST body is assigned to the body property and
not params. Fixes the feedback form and any other POST endpoints that were
expecting a parsed object from a URL-encoded body.~~

Replaced all uses of the `body` field in request objects with `params` so that URL-encoded POST / PUT request bodies can be parsed correctly.

Fixes #163.

r? @cvan @yangshun @at-kevinlau
