### PR TITLE
Add callback to db.redis

### DIFF
--- a/db.js
+++ b/db.js
@@ -40,7 +40,7 @@ var redisURL = url.parse(settings.REDIS_URL);
  *     export REDIS_URL='redis://localhost:6379'
  *
  */
- function redisClient() {
+ function redisClient(callback) {
     var client = redis.createClient(parseInt(redisURL.port || '6379', 10),
         redisURL.hostname || 'localhost');
 
@@ -67,6 +67,12 @@ var redisURL = url.parse(settings.REDIS_URL);
             redis.select(db);
             redis.send_anyways = false;
         });
+
+        if (callback) {
+            client.on('ready', function() {
+                callback(client);
+            });
+        }
     }
 
     return client;


### PR DESCRIPTION
Changes `db.redis` to accept a callback so that client code doesn't have to manually set a handler for the redis client.
