### PR TITLE
always wipe database for other npm `test-*` scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,11 @@
     "start": "node index.js",
     "dev": "NODE_ENV=development GALAXY_API_SETTINGS=./settings_dev.js nodemon index.js",
     "prod": "NODE_ENV=production GALAXY_API_SETTINGS=./settings_prod.js node index.js",
-    "test": "GALAXY_API_SETTINGS=./settings_test.js gulp refreshdb --no-prompt > /dev/null && GALAXY_API_SETTINGS=./settings_test.js ./node_modules/lab/bin/lab",
-    "test-keepdb": "GALAXY_API_SETTINGS=./settings_test.js ./node_modules/lab/bin/lab",
-    "test-verbose": "GALAXY_API_SETTINGS=./settings_test.js ./node_modules/lab/bin/lab -c -L",
-    "test-cover": "GALAXY_API_SETTINGS=./settings_test.js ./node_modules/lab/bin/lab -c -r html -o ./test/artifacts/coverage.html && open ./test/artifacts/coverage.html"
+    "refreshdb-test": "GALAXY_API_SETTINGS=./settings_test.js gulp refreshdb --no-prompt > /dev/null",
+    "test": "npm run refreshdb-test && GALAXY_API_SETTINGS=./settings_test.js ./node_modules/lab/bin/lab",
+    "test-keepdb": "npm run refreshdb-test && GALAXY_API_SETTINGS=./settings_test.js ./node_modules/lab/bin/lab",
+    "test-verbose": "npm run refreshdb-test && GALAXY_API_SETTINGS=./settings_test.js ./node_modules/lab/bin/lab -c -L",
+    "test-cover": "npm run refreshdb-test && GALAXY_API_SETTINGS=./settings_test.js ./node_modules/lab/bin/lab -c -r html -o ./test/artifacts/coverage.html && open ./test/artifacts/coverage.html"
   },
   "version": "0.0.5"
 }


### PR DESCRIPTION
we were already wiping the test database for `npm test`, but I forgot to update the other scripts.