### PR TITLE
fix `db.query` test (blocks PRs #321 and #334)

### DIFF
--- a/test/lib/db.js
+++ b/test/lib/db.js
@@ -135,7 +135,7 @@ lab.experiment('db.query', function () {
     expect(function () {
 
       db.connect(settings.POSTGRES_URL);
-      db.query('SELECT 1 FROM games', function (err, result) {
+      db.query('SELECT 1', function (err, result) {
 
         expect(result.rowCount).to.equal(1);
         done();


### PR DESCRIPTION
was causing intermittent test failures if `games` table was empty.